### PR TITLE
Use SaleCountry in params if set instead of SaleCountryDefault constant

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -16,7 +16,13 @@ type RequestParams map[string]string
 func PerformRequest(params RequestParams, apiKey string) (*GoogleResponse, error) {
 	var requestSlices []Slice
 	var googleRequest GoogleRequest
-	googleRequest.SaleCountry = SaleCountryDefault
+
+	if params[SaleCountry] != "" {
+		googleRequest.SaleCountry = params[SaleCountry]
+	} else {
+		googleRequest.SaleCountry = SaleCountryDefault
+	}
+
 	googleRequest.Refundable = false
 	adultPassengers, _ := strconv.Atoi(params[PassengersNumber])
 	googleRequest.AdultCount = adultPassengers


### PR DESCRIPTION
Hi,

Thanks for publishing this library. Noted a small issue in that I set SaleCountry in params but it was ignored because you always use the default one set in constants. Modified it to actually allow passing SaleCountry in params.
